### PR TITLE
Make signal resetting more cross platform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+janet_modules/


### PR DESCRIPTION
The original code was linux specific, required feature test macros, and
did not compile on MacOS (and possibly BSD). The NSIG trick, although
not posix, is actually quite portable and easy to extend. Since signal
can only cause one kind of error (invalid signal given), we can ignore
it and iterate all possible signals.